### PR TITLE
use correct PfundsSchlingel name "Lünda" instead of twink char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.5
+
+- fix PfundsSchlingel name
+
 # 2.2.4
 
 - Added PfundsSchlingel to allow Invites

--- a/GuildRecruitment.lua
+++ b/GuildRecruitment.lua
@@ -41,7 +41,7 @@ local guildOfficers =
     "Knubbsi",
     "Kritze",
     "Lucifia",
-    "Lündra",
+    "Lünda",
     "Meltfacé",
     "Naikjin",
     "Pfeilgiftfro",

--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -2,7 +2,7 @@
 ## Title: Schlingel Inc
 ## Notes: Visit DerHauges Discord for more information: https://discord.gg/KXkyUZW
 ## Author: Cricksu, Pudi, Canasterzaster
-## Version: 2.2.4
+## Version: 2.2.5
 ## SavedVariablesPerCharacter: CharacterDeaths, SchlingelOptionsDB
 
 # Notwendiges externe Abhängigkeiten aus dem Lib Folder


### PR DESCRIPTION
Der Charakter mit dem PfundsSchlingel Rang heißt "Lünda" ohne "r". Der Char mit "r" ist sein Twink ohne den notwendigen Run.

Ref. Bug Report: https://discord.com/channels/454336351509282827/1353113407791960176/1400812526089797793